### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compile-mod.yml
+++ b/.github/workflows/compile-mod.yml
@@ -1,5 +1,8 @@
 name: Compile and Release Minecraft Mod
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Kaloyan501/Mod_Disable/security/code-scanning/1](https://github.com/Kaloyan501/Mod_Disable/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required for the workflow. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `contents: write` for creating releases and uploading assets.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
